### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ scikit-learn~=1.1.3
 pandas~=1.5.3
 numpy~=1.23.4
 matplotlib~=3.6.1
+traitlets==5.9.0
 jupyter-server-proxy>=1.5.0
 jupyter-server>=2.4.0


### PR DESCRIPTION
Fixes 

> TypeError: warn() missing 1 required keyword-only argument: 'stacklevel'

when starting jupyter-notbook from docker